### PR TITLE
chore: [SITE-5866] Point WordPress fixture API at 6.9.4

### DIFF
--- a/releases.atom
+++ b/releases.atom
@@ -16,6 +16,18 @@
 	<generator uri="https://wordpress.org/" version="5.0.2-alpha-44105">WordPress</generator>
 	<entry>
 		<author>
+			<name>WordPress Core Team</name>
+		</author>
+		<title type="html"><![CDATA[WordPress 6.9.4 Release]]></title>
+		<link rel="alternate" type="text/html" href="https://wordpress.org/news/2026/03/wordpress-6-9-4-release/" />
+		<id>https://wordpress.org/news/?p=20184</id>
+		<updated>2026-03-12T16:23:07Z</updated>
+		<published>2026-03-11T15:34:58Z</published>
+		<category scheme="https://wordpress.org/news" term="Releases" />
+		<summary type="html"><![CDATA[WordPress 6.9.4 is now available.]]></summary>
+	</entry>
+	<entry>
+		<author>
 			<name>Ian Dunn</name>
 						<uri>https://profiles.wordpress.org/iandunn</uri>
 					</author>

--- a/version-check.json
+++ b/version-check.json
@@ -2,20 +2,20 @@
   "offers": [
     {
       "response": "upgrade",
-      "download": "https://downloads.wordpress.org/release/wordpress-5.0.1.zip",
+      "download": "https://downloads.wordpress.org/release/wordpress-6.9.4.zip",
       "locale": "en_US",
       "packages": {
-        "full": "https://downloads.wordpress.org/release/wordpress-5.0.1.zip",
-        "no_content": "https://downloads.wordpress.org/release/wordpress-5.0.1-no-content.zip",
-        "new_bundled": "https://downloads.wordpress.org/release/wordpress-5.0.1-new-bundled.zip",
+        "full": "https://downloads.wordpress.org/release/wordpress-6.9.4.zip",
+        "no_content": "https://downloads.wordpress.org/release/wordpress-6.9.4-no-content.zip",
+        "new_bundled": "https://downloads.wordpress.org/release/wordpress-6.9.4-new-bundled.zip",
         "partial": false,
         "rollback": false
       },
-      "current": "5.0.1",
-      "version": "5.0.1",
-      "php_version": "5.2.4",
-      "mysql_version": "5.0",
-      "new_bundled": "5.0",
+      "current": "6.9.4",
+      "version": "6.9.4",
+      "php_version": "7.2.24",
+      "mysql_version": "5.5.5",
+      "new_bundled": "6.7",
       "partial_version": false
     },
     {


### PR DESCRIPTION
## Summary

- `version-check.json`: set `offers[0]` to WordPress 6.9.4 (version + download +
  packages). `findLatestVersion` reads `offers[0].version`, so this is the
  update target the fixture advertises.
- `releases.atom`: prepend a WordPress 6.9.4 entry (real release-post URL
  https://wordpress.org/news/2026/03/wordpress-6-9-4-release/) as the first
  entry, so `project:release-node` and the update message resolve 6.9.4.

## Context

[SITE-5866](https://getpantheon.atlassian.net/browse/SITE-5866)

Paired with the `default` branch swap to WordPress 6.9.3 (pantheon-wp-fixture#609)
and update-tool#145. `testWordPressUpdate` then sees 6.9.3 -> 6.9.4 and
`wp core verify-checksums` runs against a real release.

## Test plan

- [ ] Merge #609 + this; push tag `6.9.3`
- [ ] update-tool#145 CI: `testWordPressUpdate` green on PHP 8.2
